### PR TITLE
Support for pytest-html to control logs better

### DIFF
--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -67,6 +67,7 @@ RUN pip install ipaddr \
                 pylint==1.8.1 \
                 pyro4 \
                 pytest-repeat \
+                pytest-html \
                 pytest-xdist==1.28.0 \
                 pytest==4.6.5 \
                 redis \


### PR DESCRIPTION
The current stdout file which also includes the dut logs are very verbose and noisy.

We have manually installed it in the sonic-mgmt docker in our organization and tuned the pytest settings to produce very helpful and concise logs.

pytest-html plugins can be used to post-process the output in various ways based on our different and unique organizational needs.

Hence proposing to add this pkt to the docker file

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did it**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
